### PR TITLE
Fixed error I did before

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ bne $a0,10,loop
 #include<stdlib.h>
 int main(){  
   srand(time(NULL));
-  int r = rand();
+  int r = rand()%10;
   printf("%i", r);
   return 0;
 }   


### PR DESCRIPTION
Fixed the lack of %10 for a number between 0 and 9 in the random number generator in C that I made.

Also, a question:
Do you mean 'generate a value between 0 and 9'? Because a0 on 10 means that it'll generate a value from 0 to 9, not including 10, so if that is true, I'll modify it on the pull request before you accept it.

This also means that rand()%10 would need to be changed to rand()%11, if you want it to generate a value from 0 to 10, including 10.

"y = rand() % x" means "0 =< y < x", so it doesn't include the upper bound.